### PR TITLE
fix: initMethod should be lazy executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,13 @@ class Base extends EventEmitter {
       assert(is.generatorFunction(this[options.initMethod]),
         `[sdk-base] this.${options.initMethod} should be a generator function.`);
 
-      co(this[options.initMethod].bind(this))
-        .then(() => this.ready(true))
-        .catch(err => this.ready(err));
+      process.nextTick(() => {
+        co(this[options.initMethod].bind(this))
+          .then(() => this.ready(true))
+          .catch(err => this.ready(err));
+      });
     }
+    this.options = options || {};
     this._ready = false;
     this._readyError = null;
     this._readyCallbacks = [];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,21 +70,26 @@ describe('sdk-base', () => {
 
   describe('options.initMethod', () => {
     class Client extends Base {
-      constructor() {
-        super({
+      constructor(options) {
+        super(Object.assign({
           initMethod: 'init',
-        });
+        }, options));
+        this.foo = 'foo';
       }
 
       * init() {
+        assert(this.foo === 'foo');
         yield cb => setTimeout(cb, 500);
         this.foo = 'bar';
       }
     }
 
     it('should auto init with options.initMethod', function* () {
-      const client = new Client();
-      assert(client.foo === undefined);
+      const client = new Client({ a: 'a' });
+      assert.deepEqual(client.options, {
+        a: 'a',
+        initMethod: 'init',
+      });
       yield client.ready();
       yield client.ready();
       assert(client.foo === 'bar');


### PR DESCRIPTION
```js
class Client extends Base {
  constructor(options) {
    super({
      initMethod: 'init',
    });
    this.options = options;
  }

  * init() {
    assert(this.options); // 这里需要能拿到 options
  }
}
```