### PR TITLE
fix: avoid duplicate error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,9 @@ class Base extends EventEmitter {
     } else if (flagOrFunction instanceof Error) {
       this._ready = false;
       this._readyError = flagOrFunction;
-      this.emit('error', flagOrFunction);
+      if (!this._readyCallbacks.length) {
+        this.emit('error', flagOrFunction);
+      }
     } else {
       this._ready = flagOrFunction;
     }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "autod": "^2.7.1",
-    "egg-bin": "^2.2.0",
-    "egg-ci": "^1.1.0",
-    "eslint": "^3.15.0",
+    "egg-bin": "^2.4.0",
+    "egg-ci": "^1.5.0",
+    "eslint": "^3.17.1",
     "eslint-config-egg": "^3.2.0",
     "pedding": "^1.1.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -153,6 +153,17 @@ describe('sdk-base', () => {
         done();
       });
     });
+
+    it('should not emit error event if readyCallback not empty', done => {
+      const client = new ErrorClient();
+      client.ready(err => {
+        assert(err.message === 'init error');
+        setImmediate(done);
+      });
+      client.once('error', () => {
+        done(new Error('should not run here'));
+      });
+    });
   });
 
   describe('generator event listener', () => {


### PR DESCRIPTION
避免重复的异常处理

```js

class ErrorClient extends Base {
  constructor() {
    super();
    setImmediate(() => {
      this.ready(new Error('mock error'));
    });
  }
}

const client1 = new ErrorClient();
client1.ready(err => {
   assert(err && err.message === 'mock error');
});
client1.once('error', err => {
   // 上面已经处理了 ready，这里不应该再 emit error 事件了
   assert.ifError(err);
});
```