### PR TITLE
Let options.initMethod support functions that return promise

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,6 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - npm run test
 
 build: off

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,6 +84,21 @@ describe('sdk-base', () => {
       }
     }
 
+    class Client2 extends Base {
+      constructor(options) {
+        super(Object.assign({
+          initMethod: 'init',
+        }, options));
+        this.foo = 'foo';
+      }
+
+      init() {
+        assert(this.foo === 'foo');
+        this.foo = 'bar';
+        return Promise.resolve();
+      }
+    }
+
     it('should auto init with options.initMethod', function* () {
       const client = new Client({ a: 'a' });
       assert.deepEqual(client.options, {
@@ -101,6 +116,17 @@ describe('sdk-base', () => {
         assert.ifError(err);
         done();
       });
+    });
+
+    it('should support options.initMethod that return promise', function* () {
+      const client = new Client2({ a: 'a' });
+      assert.deepEqual(client.options, {
+        a: 'a',
+        initMethod: 'init',
+      });
+      yield client.ready();
+      yield client.ready();
+      assert(client.foo === 'bar');
     });
   });
 


### PR DESCRIPTION
The main purpose is to support async functions.

```js
class Client extends Base {
  constructor() {
    super({ initMethod: 'init' });
  }

  async init() {
    // xxx
  }
}
```