### PR TITLE
feat: optimize performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ class Base extends EventEmitter {
     }
 
     if (this._ready || this._readyError) {
-      this._readyCallbacks.splice(0, Infinity).forEach(callback => {
+      this._readyCallbacks.splice(0, this._readyCallbacks.length).forEach(callback => {
         process.nextTick(() => {
           callback(this._readyError);
         });


### PR DESCRIPTION
Change `Infinity` to `this._readyCallbacks.length`.
I have tested in little number:

<img src="https://raw.githubusercontent.com/brizer/graph-bed/master/img/20190927095144.png"/>

and large number:

<img src="https://raw.githubusercontent.com/brizer/graph-bed/master/img/20190927100947.png"/>

The hack of Infinity is unnecessary. If there is anything I didn't think about, please correct me.