### PR TITLE
make sure close behavior correct

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,14 +98,17 @@ export abstract class Base<T = any> extends ReadyEventEmitter {
     if (this.#closed) {
       return;
     }
-    this.#closed = true;
-    const closeMethod = Reflect.get(this, '_close') as () => Promise<void>;
+    const closeMethod = Reflect.get(this, '_close');
+
     if (typeof closeMethod !== 'function') {
+      this.#closed = true;
       return;
     }
 
     try {
-      await closeMethod.apply(this);
+      const result = await closeMethod.apply(this);
+      this.#closed = true;
+      return result;
     } catch (err) {
       this.emit('error', err);
     }


### PR DESCRIPTION
1. 如果在 closeMethod 前设置 close = true ，那么如果 cloaseMethod 执行失败时，close 的值就是错误的。
2. close需要将用户定义的_close方法的返回值返回，以便于用户有关于返回值的操作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of the close operation, ensuring that the closure logic executes correctly before marking the instance as closed.
  
- **New Features**
	- Enhanced flexibility in the retrieval and execution of the close method, allowing for better control flow and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->